### PR TITLE
Change style convention for string alias use

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,7 +214,7 @@ private int port;
 
 ## Others
 ### String
-Prefer `String` instead of `string`, although this is not required.
+Prefer `string` instead of `String` (i.e. `System.String`), the C# alias should always be used.
 
 ### C style code
 Avoid it like hell. Code like the following should not be on the code base:


### PR DESCRIPTION
I don't recall we ever used `String` over `string`, and I think we should change this.

@kkozmic @hammett do you have a problem with this change?